### PR TITLE
Improve grammar and add support for comments

### DIFF
--- a/grammars/nusmv.cson
+++ b/grammars/nusmv.cson
@@ -14,7 +14,7 @@
     'name': 'constant.numeric.nusmv'
   }
   {
-    'match': '\\b(MODULE|DEFINE|MDEFINE|CONSTANTS|VAR|IVAR|FROZENVAR|INIT|TRANS|INVAR|SPEC|CTLSPEC|LTLSPEC|PSLSPEC|COMPUTE|NAME|INVARSPEC|FAIRNESS|JUSTICE|COMPASSION|ISA|ASSIGN|CONSTANRAINT|SIMPWFF|LTLWFF|PSLWFF|COMPWFF|IN|MIN|MAX|MIRROR|PRED|PREDICATES)\\b'
+    'match': '\\b(MODULE|DEFINE|MDEFINE|CONSTANTS|VAR|IVAR|FROZENVAR|INIT|TRANS|INVAR|SPEC|CTLSPEC|LTLSPEC|PSLSPEC|COMPUTE|NAME|INVARSPEC|FAIRNESS|JUSTICE|COMPASSION|ISA|ASSIGN|CONSTANRAINT|SIMPWFF|LTLWFF|PSLWFF|COMPWFF|IN|MIN|MAX|MIRROR|PRED|PREDICATES|case|esac)\\b'
     'name': 'control.keyword.nusmv'
   }
   {
@@ -28,5 +28,18 @@
   {
     'match': '\\b(signed|unsigned)\\b'
     'name': 'modifier.storage.nusmv'
+  },
+  {
+    'begin': '--',
+    'end': '$\\n?',
+    'name': 'comment.line.nusmv',
+  },
+  {
+    'match': '\\b(?-i:init|next)\\b'
+    'name': 'entity.name.function.nusmv'
+  },
+  {
+    'match': '\\b(?-i:EX|AX|EF|AF|EG|AG|E|F|O|G|H|X|Y|Z|A|U|S|V|T|BU|EBF|ABF|EBG|ABG|count|toint|resize|select|process)\\b'
+    'name': 'support.function.nusmv'
   }
 ]

--- a/settings/language-nusmv.cson
+++ b/settings/language-nusmv.cson
@@ -1,0 +1,3 @@
+'.source.nusmv':
+    'editor':
+        'commentStart': '-- '


### PR DESCRIPTION
Add support for comments and various other functions and keywords to the grammar and use the NuSMV syntax for comments when toggling comments.